### PR TITLE
Fixes indentation of pre-formatted text

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,38 +9,50 @@ To try out the example, load Campanulaceae.owl into Protege. Then run the reason
 
 * The node in the phylogeny that instantiates a phyloreference:
 
-  ```has_Descendant value Campanula_latifolia and excludes_lineage_to value Lobelia```
+  ```
+  has_Descendant value Campanula_latifolia and excludes_lineage_to value Lobelia
+  ```
 
 * The clade defined by a phyloreference:
 
-  ```has_Ancestor some (has_Descendant value Campanula_latifolia and excludes_lineage_to value Lobelia)```
+  ```
+  has_Ancestor some (has_Descendant value Campanula_latifolia and excludes_lineage_to value Lobelia)
+  ```
 
 * The tip nodes included by a phyloreference:
 
-  ```TU and has_Ancestor some (has_Descendant value Campanula_latifolia and excludes_lineage_to value Lobelia)```
+  ```
+  TU and has_Ancestor some (has_Descendant value Campanula_latifolia and excludes_lineage_to value Lobelia)
+  ```
 
 This series of patterns in essence corresponds to branch-based [phylogenetic clade definitions] [1], i.e., definitions using exclusion. We can use these to build phyloreferences corresponding to node-based clade definitions (i.e., definitions using a most recent common ancestor), by using the parent of the nodes that include one but exclude the other lineage(s).
 
 * For example, for the most recent common ancestor of Campanula_latifolia and Lobelia, we define the parent of the two nodes that have one as descendent and exclude the other:
 
   ```
-has_Child some (has_Descendant value Campanula_latifolia and excludes_lineage_to value Lobelia)
-and
-has_Child some (has_Descendant value Lobelia and excludes_lineage_to value Campanula_latifolia)
+  has_Child some (has_Descendant value Campanula_latifolia and excludes_lineage_to value Lobelia)
+  and
+  has_Child some (has_Descendant value Lobelia and excludes_lineage_to value Campanula_latifolia)
   ```
 
 * We can make this shorter by defining a phyloreference for each of the two components, which we name here Campanula!Lobelia and Lobelia!Campanula:
 
-  ```has_Child some Campanula!Lobelia and has_Child some Lobelia!Campanula```
+  ```
+  has_Child some Campanula!Lobelia and has_Child some Lobelia!Campanula
+  ```
 
 * We can use the same pattern variations as above to obtain the whole clade or the tip nodes included by this phyloreference. For example:
 
-  ```has_Ancestor some (has_Child some Campanula!Lobelia and has_Child some Lobelia!Campanula)```
+  ```
+  has_Ancestor some (has_Child some Campanula!Lobelia and has_Child some Lobelia!Campanula)
+  ```
 
 The Tetrapoda.owl example (same procedure: load into Protege, run reasoner, switch to DL Query tab) defines phyloreferences for 3 different definitions of Tetrapoda. (Note that for the DL query to return the phyloreference classes, the "Equivalent Classes" option needs to be checked.)
 
 * It also demonstrates use of an apomorphy-based phyloreferences:
 
-  ```TU and has_Ancestor some (has_Progenitor some ('has part' some 'manual digit'))```
+  ```
+  TU and has_Ancestor some (has_Progenitor some ('has part' some 'manual digit'))
+  ```
 
 [1]: http://dx.doi.org/10.1080/106351591007453 (P. C. Sereno, “The logical basis of phylogenetic taxonomy.,” Systematic Biology, vol. 54, no. 4, pp. 595–619, Aug. 2005.)


### PR DESCRIPTION
Apparently the rendering of indented pre-formatted (fenced) code blocks has changed on Github - it wasn't looking correct anymore.