### PR TITLE
Fixes and improvements for Maximum / Minimum Clade subclasses of Phyloreference

### DIFF
--- a/phyloref.ofn
+++ b/phyloref.ofn
@@ -198,13 +198,13 @@ SubClassOf(:Phyloreference ObjectIntersectionOf(obo:CDAO_0000140 ObjectSomeValue
 
 AnnotationAssertion(obo:IAO_0000115 :PhyloreferenceUsingMaximumClade "Phyloreference that uses a maximum clade definition, such as a branch-based clade definition with excluded specifiers.")
 AnnotationAssertion(rdfs:label :PhyloreferenceUsingMaximumClade "Phyloreference using maximum clade")
-SubClassOf(:PhyloreferenceUsingMaximumClade :Phyloreference)
+EquivalentClasses(:PhyloreferenceUsingMaximumClade ObjectIntersectionOf(:Phyloreference ObjectSomeValuesFrom(:excludes_TU obo:CDAO_0000138) ObjectSomeValuesFrom(:includes_TU obo:CDAO_0000138)))
 
 # Class: :PhyloreferenceUsingMinimumClade (Phyloreference using minimum clade)
 
 AnnotationAssertion(obo:IAO_0000115 :PhyloreferenceUsingMinimumClade "Phyloreferences that uses a minimum clade definition, such as a last common ancestor definition or node-based definition.")
 AnnotationAssertion(rdfs:label :PhyloreferenceUsingMinimumClade "Phyloreference using minimum clade")
-SubClassOf(:PhyloreferenceUsingMinimumClade :Phyloreference)
+EquivalentClasses(:PhyloreferenceUsingMinimumClade ObjectIntersectionOf(:Phyloreference ObjectComplementOf(ObjectSomeValuesFrom(:excludes_TU obo:CDAO_0000138)) ObjectSomeValuesFrom(:includes_TU obo:CDAO_0000138)))
 
 # Class: :PhyloreferenceWithReferenceTree (:PhyloreferenceWithReferenceTree)
 

--- a/phyloref.ofn
+++ b/phyloref.ofn
@@ -196,13 +196,13 @@ SubClassOf(:Phyloreference ObjectIntersectionOf(obo:CDAO_0000140 ObjectSomeValue
 
 # Class: :PhyloreferenceUsingMaximumClade (Phyloreference using maximum clade)
 
-AnnotationAssertion(obo:IAO_0000115 :PhyloreferenceUsingMaximumClade "Phyloreference that uses a maximum clade definition, such as a last common ancestor definition or node-based definition.")
+AnnotationAssertion(obo:IAO_0000115 :PhyloreferenceUsingMaximumClade "Phyloreference that uses a maximum clade definition, such as a branch-based clade definition with excluded specifiers.")
 AnnotationAssertion(rdfs:label :PhyloreferenceUsingMaximumClade "Phyloreference using maximum clade")
 SubClassOf(:PhyloreferenceUsingMaximumClade :Phyloreference)
 
 # Class: :PhyloreferenceUsingMinimumClade (Phyloreference using minimum clade)
 
-AnnotationAssertion(obo:IAO_0000115 :PhyloreferenceUsingMinimumClade "Phyloreferences that uses a minimum clade definition, such as a branch-based clade definition with excluded specifiers.")
+AnnotationAssertion(obo:IAO_0000115 :PhyloreferenceUsingMinimumClade "Phyloreferences that uses a minimum clade definition, such as a last common ancestor definition or node-based definition.")
 AnnotationAssertion(rdfs:label :PhyloreferenceUsingMinimumClade "Phyloreference using minimum clade")
 SubClassOf(:PhyloreferenceUsingMinimumClade :Phyloreference)
 

--- a/phyloref.ofn
+++ b/phyloref.ofn
@@ -204,7 +204,7 @@ EquivalentClasses(:PhyloreferenceUsingMaximumClade ObjectIntersectionOf(:Phylore
 
 AnnotationAssertion(obo:IAO_0000115 :PhyloreferenceUsingMinimumClade "Phyloreferences that uses a minimum clade definition, such as a last common ancestor definition or node-based definition.")
 AnnotationAssertion(rdfs:label :PhyloreferenceUsingMinimumClade "Phyloreference using minimum clade")
-EquivalentClasses(:PhyloreferenceUsingMinimumClade ObjectIntersectionOf(:Phyloreference ObjectComplementOf(ObjectSomeValuesFrom(:excludes_TU obo:CDAO_0000138)) ObjectSomeValuesFrom(:includes_TU obo:CDAO_0000138)))
+EquivalentClasses(:PhyloreferenceUsingMinimumClade ObjectIntersectionOf(:Phyloreference ObjectSomeValuesFrom(obo:CDAO_0000149 ObjectIntersectionOf(ObjectSomeValuesFrom(:excludes_TU obo:CDAO_0000138) ObjectSomeValuesFrom(:includes_TU obo:CDAO_0000138)))))
 
 # Class: :PhyloreferenceWithReferenceTree (:PhyloreferenceWithReferenceTree)
 

--- a/phyloref.ofn
+++ b/phyloref.ofn
@@ -11,7 +11,7 @@ Prefix(owl2xml:=<http://www.w3.org/2006/12/owl2-xml#>)
 
 
 Ontology(<http://ontology.phyloref.org/phyloref.owl>
-<http://ontology.phyloref.org/2018-12-14/phyloref.owl>
+<http://ontology.phyloref.org/2020-11-09/phyloref.owl>
 Import(<http://purl.obolibrary.org/obo/cdao.owl>)
 Annotation(dc:creator "Hilmar Lapp")
 Annotation(dc:description "The Phyloreferencing Ontology is an application ontology for defining, computing with, and resolving phylogenetic clade definitions in the form of logic expressions."@en)


### PR DESCRIPTION
Fixes #34, confusion of minimum and maximum clade definitions. Also adds logical definitions for these Phyloreference subclasses.