### PR TITLE
Adds has_outside_TU property for maximum clade defs

### DIFF
--- a/phyloref.ofn
+++ b/phyloref.ofn
@@ -33,9 +33,9 @@ Declaration(Class(obo:ECO_0000000))
 Declaration(Class(obo:OBI_0302910))
 Declaration(Class(owl:Thing))
 Declaration(ObjectProperty(:excludes_TU))
-Declaration(ObjectProperty(:excludes_TU2))
 Declaration(ObjectProperty(:excludes_lineage_to))
 Declaration(ObjectProperty(:has_Sibling))
+Declaration(ObjectProperty(:has_outside_TU))
 Declaration(ObjectProperty(:includes_TU))
 Declaration(ObjectProperty(:matches_TU))
 Declaration(ObjectProperty(obo:BFO_0000050))
@@ -69,12 +69,8 @@ AnnotationAssertion(rdfs:seeAlso :newick_expression <https://en.wikipedia.org/wi
 
 # Object Property: :excludes_TU (:excludes_TU)
 
-SubObjectPropertyOf(:excludes_TU obo:CDAO_0000161)
+SubObjectPropertyOf(:excludes_TU :has_outside_TU)
 ObjectPropertyRange(:excludes_TU obo:CDAO_0000138)
-
-# Object Property: :excludes_TU2 (:excludes_TU2)
-
-SubObjectPropertyOf(:excludes_TU2 obo:CDAO_0000161)
 
 # Object Property: :excludes_lineage_to (:excludes_lineage_to)
 
@@ -84,6 +80,10 @@ SubObjectPropertyOf(:excludes_lineage_to obo:CDAO_0000161)
 
 SubObjectPropertyOf(:has_Sibling :excludes_lineage_to)
 SymmetricObjectProperty(:has_Sibling)
+
+# Object Property: :has_outside_TU (:has_outside_TU)
+
+SubObjectPropertyOf(:has_outside_TU obo:CDAO_0000161)
 
 # Object Property: :matches_TU (:matches_TU)
 
@@ -229,10 +229,10 @@ AnnotationAssertion(rdfs:label obo:OBI_0302910 "prediction")
 
 
 SubObjectPropertyOf(ObjectPropertyChain(:excludes_lineage_to obo:CDAO_0000187) :excludes_TU)
-SubObjectPropertyOf(ObjectPropertyChain(:excludes_lineage_to obo:CDAO_0000187) :excludes_TU2)
 SubObjectPropertyOf(ObjectPropertyChain(:excludes_lineage_to obo:CDAO_0000187 :matches_TU) :excludes_TU)
 SubObjectPropertyOf(ObjectPropertyChain(:has_Sibling obo:CDAO_0000174) :excludes_lineage_to)
 SubObjectPropertyOf(ObjectPropertyChain(:has_Sibling obo:CDAO_0000179) obo:CDAO_0000179)
+SubObjectPropertyOf(ObjectPropertyChain(obo:CDAO_0000144 :excludes_TU) :has_outside_TU)
 SubObjectPropertyOf(ObjectPropertyChain(obo:CDAO_0000149 :has_Sibling) obo:CDAO_0000149)
 SubObjectPropertyOf(ObjectPropertyChain(obo:CDAO_0000174 obo:CDAO_0000187) :includes_TU)
 SubObjectPropertyOf(ObjectPropertyChain(obo:CDAO_0000174 obo:CDAO_0000187 :matches_TU) :includes_TU)


### PR DESCRIPTION
This property supplements the excludes_TU property. Because it is not known in advance in which topological relationship the external specifiers stand to each other if there is more than one, only one can use the external_TU property in a given logical expression.

Algorithm outline:  For defining the node that splits from the externals, we create a conjunction of “includes_TU some internal_sp_i” for all internal specifiers internal_sp_i. (2) We don’t know the most closely related external specifier external_sp_i.  So, we choose one and intersect with “excludes_TU some external_sp_i”. (3) For the remaining external specifiers external_sp_{j \in 1..n \ I} (n = number of external specifiers), we require that they be "outside the clade”: Generate a conjunction of “has_outside_TU some external_sp_j” for all j != i. Intersect the result with the conjunction from (1). (4) Repeat #2 and #3 for each external specifier.