### PR TITLE
Corrects relationship hierarchy for OpenBioDiv terms

### DIFF
--- a/tcan.ofn
+++ b/tcan.ofn
@@ -18,7 +18,7 @@ Prefix(openbiodiv:=<http://openbiodiv.net/>)
 
 
 Ontology(<http://ontology.phyloref.org/tcan.owl>
-<http://ontology.phyloref.org/2018-12-14/tcan.owl>
+<http://ontology.phyloref.org/2021-03-15/tcan.owl>
 Annotation(dc:creator "Hilmar Lapp")
 Annotation(dc:rights "Axioms under the namespace of this ontology are released under the Creative Commons Zero 1.0 public domain waiver. Terms and axioms imported from other sources are under the licenses of the vocabularies they are defined in (see rdfs:isDefinedBy annotations).")
 Annotation(dc:title "Ontology for Taxon Concepts And Names")

--- a/tcan.ofn
+++ b/tcan.ofn
@@ -24,6 +24,8 @@ Annotation(dc:rights "Axioms under the namespace of this ontology are released u
 Annotation(dc:title "Ontology for Taxon Concepts And Names")
 Annotation(dcterms:source openbiodiv:ontology)
 Annotation(dcterms:source obo:NOMEN)
+Annotation(dcterms:source <http://rs.tdwg.org/dwc/iri/>)
+Annotation(dcterms:source <http://rs.tdwg.org/dwc/terms/>)
 Annotation(dcterms:source <http://rs.tdwg.org/ontology/voc/TaxonConcept>)
 Annotation(dcterms:source <http://rs.tdwg.org/ontology/voc/TaxonName>)
 Annotation(rdfs:comment "The Ontology for Taxon Concepts And Names (TCAN) is an application ontology for expressing, matching, and resolving taxon concepts and their names as encountered in the wild, such as in publications, taxon mentions, clade definitions, etc. One of the key use cases for which it is being developed is for expressing and matching specifiers (in essence taxon concepts) used in clade definitions.

--- a/tcan.ofn
+++ b/tcan.ofn
@@ -339,7 +339,6 @@ AnnotationAssertion(rdfs:comment openbiodiv:nameAccordingTo "The reference to th
     only be used with IRI's"@en)
 AnnotationAssertion(rdfs:isDefinedBy openbiodiv:nameAccordingTo openbiodiv:openbiodiv-ontology)
 SubObjectPropertyOf(openbiodiv:nameAccordingTo dwciri:nameAccordingTo)
-SubObjectPropertyOf(openbiodiv:nameAccordingTo tc:accordingTo)
 
 # Object Property: openbiodiv:replacementName (has replacement name)
 
@@ -357,7 +356,7 @@ TransitiveObjectProperty(openbiodiv:replacementName)
 AnnotationAssertion(rdfs:isDefinedBy openbiodiv:scientificName openbiodiv:openbiodiv-ontology)
 AnnotationAssertion(rdfs:label openbiodiv:scientificName "has scientific name"@en)
 SubObjectPropertyOf(openbiodiv:scientificName openbiodiv:taxonomicName)
-SubObjectPropertyOf(openbiodiv:scientificName tc:hasName)
+SubObjectPropertyOf(openbiodiv:scientificName dwciri:scientificName)
 ObjectPropertyDomain(openbiodiv:scientificName openbiodiv:TaxonomicConcept)
 ObjectPropertyRange(openbiodiv:scientificName openbiodiv:ScientificName)
 
@@ -373,6 +372,7 @@ ObjectPropertyRange(openbiodiv:taxonomicConceptLabel openbiodiv:TaxonomicConcept
 
 AnnotationAssertion(rdfs:isDefinedBy openbiodiv:taxonomicName openbiodiv:openbiodiv-ontology)
 AnnotationAssertion(rdfs:label openbiodiv:taxonomicName "has taxonomic name"@en)
+SubObjectPropertyOf(openbiodiv:taxonomicName tc:hasName)
 ObjectPropertyDomain(openbiodiv:taxonomicName openbiodiv:TaxonomicConcept)
 ObjectPropertyRange(openbiodiv:taxonomicName openbiodiv:TaxonomicName)
 
@@ -382,6 +382,7 @@ AnnotationAssertion(rdfs:comment dwciri:nameAccordingTo "the IRI version of dwc:
 AnnotationAssertion(rdfs:isDefinedBy dwciri:nameAccordingTo <http://rs.tdwg.org/dwc/iri/>)
 AnnotationAssertion(rdfs:label dwciri:nameAccordingTo "name according to"@en)
 AnnotationAssertion(rdfs:seeAlso dwciri:nameAccordingTo dwc:nameAccordingTo)
+SubObjectPropertyOf(dwciri:nameAccordingTo tc:accordingTo)
 
 # Object Property: dwciri:scientificName (scientific name)
 
@@ -389,6 +390,7 @@ AnnotationAssertion(rdfs:comment dwciri:scientificName "the IRI version of dwc:s
 AnnotationAssertion(rdfs:isDefinedBy dwciri:scientificName <http://rs.tdwg.org/dwc/iri/>)
 AnnotationAssertion(rdfs:label dwciri:scientificName "scientific name"@en)
 AnnotationAssertion(rdfs:seeAlso dwciri:scientificName dwc:scientificName)
+SubObjectPropertyOf(dwciri:scientificName openbiodiv:taxonomicName)
 
 # Object Property: tc:accordingTo (according to)
 
@@ -648,7 +650,7 @@ SubClassOf(openbiodiv:ScientificName openbiodiv:TaxonomicName)
 AnnotationAssertion(rdfs:comment openbiodiv:TaxonomicConcept "A taxonomic concept in the sense of Berendsohn"@en)
 AnnotationAssertion(rdfs:isDefinedBy openbiodiv:TaxonomicConcept openbiodiv:openbiodiv-ontology)
 EquivalentClasses(openbiodiv:TaxonomicConcept dwc:Taxon)
-SubClassOf(Annotation(rdfs:isDefinedBy :tcan.owl) openbiodiv:TaxonomicConcept tc:TaxonConcept)
+EquivalentClasses(Annotation(rdfs:isDefinedBy :tcan.owl) openbiodiv:TaxonomicConcept tc:TaxonConcept)
 
 # Class: openbiodiv:TaxonomicConceptLabel (Taxon Concept Label)
 
@@ -664,7 +666,8 @@ AnnotationAssertion(rdfs:label openbiodiv:TaxonomicConceptLabel "Taxon Concept L
 AnnotationAssertion(rdfs:isDefinedBy openbiodiv:TaxonomicName openbiodiv:openbiodiv-ontology)
 AnnotationAssertion(skos:altLabel openbiodiv:TaxonomicName "Biological Name"@en)
 AnnotationAssertion(skos:prefLabel openbiodiv:TaxonomicName "Taxonomic Name"@en)
-EquivalentClasses(openbiodiv:TaxonomicName obo:NOMEN_0000030)
+EquivalentClasses(openbiodiv:TaxonomicName tn:TaxonName)
+SubClassOf(openbiodiv:TaxonomicName obo:NOMEN_0000030)
 
 # Class: openbiodiv:VernacularName (Vernacular Name)
 


### PR DESCRIPTION
These changes should bring the subproperty and subclass relationships of OpenBioDiv-O terms into consistency with the OpenBioDiv publication (http://dx.doi.org/10.1186/s13326-017-0174-5), specifically for `TaxonomicName`, `TaxonomicConcept`, `ScientificName`, and the related object properties. (Note that OpenBioDiv uses DWC for data properties)