### PR TITLE
Sets range constraints to TU on includes_TU and has_outside_TU

### DIFF
--- a/phyloref.ofn
+++ b/phyloref.ofn
@@ -95,6 +95,11 @@ SymmetricObjectProperty(:has_Sibling)
 # Object Property: :has_outside_TU (:has_outside_TU)
 
 SubObjectPropertyOf(:has_outside_TU obo:CDAO_0000161)
+ObjectPropertyRange(:has_outside_TU obo:CDAO_0000138)
+
+# Object Property: :includes_TU (:includes_TU)
+
+ObjectPropertyRange(:includes_TU obo:CDAO_0000138)
 
 # Object Property: :matches_TU (:matches_TU)
 

--- a/phyloref.ofn
+++ b/phyloref.ofn
@@ -83,10 +83,6 @@ AnnotationAssertion(rdfs:seeAlso :apomorphy obo:RO_0002200)
 SubObjectPropertyOf(:excludes_TU :has_outside_TU)
 ObjectPropertyRange(:excludes_TU obo:CDAO_0000138)
 
-# Object Property: :excludes_lineage_to (:excludes_lineage_to)
-
-SubObjectPropertyOf(:excludes_lineage_to obo:CDAO_0000161)
-
 # Object Property: :has_Sibling (:has_Sibling)
 
 SubObjectPropertyOf(:has_Sibling :excludes_lineage_to)
@@ -94,7 +90,6 @@ SymmetricObjectProperty(:has_Sibling)
 
 # Object Property: :has_outside_TU (:has_outside_TU)
 
-SubObjectPropertyOf(:has_outside_TU obo:CDAO_0000161)
 ObjectPropertyRange(:has_outside_TU obo:CDAO_0000138)
 
 # Object Property: :includes_TU (:includes_TU)


### PR DESCRIPTION
See #48. Closes #48.

Also removes questionable subproperty assertions to  [`cdao:exclude`](http://purl.obolibrary.org/obo/CDAO_0000161).